### PR TITLE
Updated UID_SETTING for rancher 2.2.x

### DIFF
--- a/collector/installation.go
+++ b/collector/installation.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	UID_SETTING            = "telemetry-uid"
+	UID_SETTING            = "install-uuid"
 	SERVER_IMAGE_SETTING   = "server-image"
 	SERVER_VERSION_SETTING = "server-version"
 )


### PR DESCRIPTION
Updated `UID_SETTING = install-uuid` to send correct uuid on telemetry stats for rancher 2.2.x 