### PR TITLE
Skip failed clusters during project collection

### DIFF
--- a/collector/project.go
+++ b/collector/project.go
@@ -54,8 +54,8 @@ func (p Project) Collect(c *CollectorOpts) interface{} {
 			projectID := parts[1]
 			cluster, err := c.Client.Cluster.ByID(clusterID)
 			if err != nil {
-				log.Errorf("Failed to get cluster %s err=%s", clusterID, err)
-				return nil
+				log.Errorf("Failed to get cluster %s for project %s err=%s", clusterID, projectID, err)
+				continue
 			}
 			nsCollection := filterNSCollectionWithProjectID(GetNamespaceCollection(c, cluster.Links["namespaces"]), projectID)
 			totalNs := len(nsCollection.Data)


### PR DESCRIPTION
Currently if any project fails to retrieve because the cluster is
missing then the entire projects node is skipped.
With this change, it simply skips the current project and
attempts to fetch the next one.