### PR TITLE
Add a cluster's cloud provider type when available

### DIFF
--- a/collector/cluster.go
+++ b/collector/cluster.go
@@ -16,6 +16,7 @@ type Cluster struct {
 	IstioTotal       int         `json:"istio"`
 	MonitoringTotal  int         `json:"monitoring"`
 	LogProviderCount LabelCount  `json:"logging"`
+	CloudProvider    LabelCount  `json:"cloudProvider"`
 }
 
 func (h Cluster) RecordKey() string {
@@ -39,6 +40,7 @@ func (h Cluster) Collect(c *CollectorOpts) interface{} {
 	h.Mem = &MemoryInfo{}
 	h.Pod = &PodInfo{}
 	h.Driver = make(LabelCount)
+	h.CloudProvider = make(LabelCount)
 
 	var cpuUtils []float64
 	var memUtils []float64
@@ -97,6 +99,11 @@ func (h Cluster) Collect(c *CollectorOpts) interface{} {
 
 		// Driver
 		h.Driver.Increment(cluster.Driver)
+
+		if cluster.RancherKubernetesEngineConfig != nil && cluster.RancherKubernetesEngineConfig.CloudProvider != nil {
+			h.CloudProvider.Increment(
+				cluster.RancherKubernetesEngineConfig.CloudProvider.Name)
+		}
 
 		// Namespace
 		nsCollection := GetNamespaceCollection(c, cluster.Links["namespaces"])


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/19231
Provider name here should match a provider we support, or a custom one [supported by kubernetes](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/).
This would only be set for RKE provisioned clusters that use a cloud provider. 
```
"cluster": {
	"driver": {
		"imported": 1,
		"rancherKubernetesEngine": 2
	},
	"cloudProvider": {
		"aws": 1,
		"ovirt": 1
	}
```