### PR TITLE
Stop resetting provider count per project

### DIFF
--- a/collector/project.go
+++ b/collector/project.go
@@ -45,6 +45,7 @@ func (p Project) Collect(c *CollectorOpts) interface{} {
 
 	p.LibraryCharts = make(LabelCount)
 	p.Orchestration = make(LabelCount)
+	p.Pipeline.SourceProvider = make(LabelCount)
 	p.Orchestration[orchestrationName] = total
 	p.Total = total
 
@@ -94,7 +95,6 @@ func (p Project) Collect(c *CollectorOpts) interface{} {
 		}
 
 		// Source provider
-		p.Pipeline.SourceProvider = make(LabelCount)
 		sourceCollection := GetSourceCodeProviderCollection(c, project.Links["sourceCodeProviders"])
 		if sourceCollection != nil {
 			p.Pipeline.Enabled = 1


### PR DESCRIPTION
Problem:
Counts for pipeline provider were being overwritten.

Solution:
Only creates a count label for providers once, instead of resetting
count label on every project.

Issue:
https://github.com/rancher/rancher/issues/19231