### PR TITLE
Added license collector

### DIFF
--- a/collector/base.go
+++ b/collector/base.go
@@ -1,10 +1,18 @@
 package collector
 
 import (
+	"time"
+
 	"github.com/rancher/telemetry/record"
 	rancherCluster "github.com/rancher/types/client/cluster/v3"
 	rancher "github.com/rancher/types/client/management/v3"
 	rancherProject "github.com/rancher/types/client/project/v3"
+)
+
+const (
+	RECORD_INSTALLATION = "installation"
+	RECORD_LICENSING    = "licensing"
+	RECORD_VERSION      = 2
 )
 
 type CollectorOpts struct {
@@ -22,10 +30,41 @@ func Register(c Collector) {
 	registered = append(registered, c)
 }
 
-func Run(record *record.Record, opt *CollectorOpts) {
-	for _, c := range registered {
-		(*record)[c.RecordKey()] = c.Collect(opt)
+func Run(opt *CollectorOpts) map[string]record.Record {
+	telemetryEnabled := IsTelemetryEnabled(opt)
+	licensed := IsLicensed(opt)
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	r := map[string]record.Record{}
+
+	if telemetryEnabled {
+		r[RECORD_INSTALLATION] = record.Record{
+			"r":  RECORD_VERSION,
+			"ts": now,
+		}
 	}
+
+	if licensed {
+		r[RECORD_LICENSING] = record.Record{
+			"r":  RECORD_VERSION,
+			"ts": now,
+		}
+	}
+
+	for _, c := range registered {
+		if c.RecordKey() == "license" && licensed {
+			r[RECORD_LICENSING][c.RecordKey()] = c.Collect(opt)
+			if !telemetryEnabled {
+				return r
+			}
+			continue
+		}
+		if telemetryEnabled {
+			r[RECORD_INSTALLATION][c.RecordKey()] = c.Collect(opt)
+		}
+	}
+
+	return r
 }
 
 func GetClusterClient(c *CollectorOpts, id string) (*rancherCluster.Client, error) {

--- a/collector/installation.go
+++ b/collector/installation.go
@@ -9,6 +9,7 @@ import (
 )
 
 const (
+	TELEMETRY_OPT_SETTING  = "telemetry-opt"
 	TELEMETRY_UID_SETTING  = "telemetry-uid"
 	SERVER_VERSION_SETTING = "server-version"
 )
@@ -157,6 +158,16 @@ func GetTelemetryUid(c *CollectorOpts) (string, bool) {
 
 func (i *Installation) GetUid(c *CollectorOpts) {
 	i.Uid, _ = GetTelemetryUid(c)
+}
+
+func IsTelemetryEnabled(c *CollectorOpts) bool {
+	telemetry, err := c.Client.Setting.ByID(TELEMETRY_OPT_SETTING)
+	if err != nil {
+		log.Errorf("Failed to get setting %s err=%s", TELEMETRY_OPT_SETTING, err)
+		return false
+	}
+
+	return (telemetry.Value == "in")
 }
 
 func init() {

--- a/collector/license.go
+++ b/collector/license.go
@@ -1,0 +1,125 @@
+package collector
+
+import (
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	SERVER_LICENSE_SETTING   = "server-license"
+	INSTALLATION_UID_SETTING = "install-uuid"
+)
+
+type License struct {
+	Key             string `json:"key"`
+	InstallationUID string `json:"installationUid"`
+	TelemetryUID    string `json:"telemetryUid"`
+	RunningNodes    int    `json:"runningNodes"`
+}
+
+func (l License) RecordKey() string {
+	return "license"
+}
+
+func (l License) Collect(c *CollectorOpts) interface{} {
+	log.Debug("Collecting License")
+
+	log.Debug("  Getting key")
+	if ok := l.GetKey(c); !ok {
+		return nil
+	}
+
+	log.Debug("  Getting Installation uid")
+	if ok := l.GetInstallationUid(c); !ok {
+		return nil
+	}
+
+	l.TelemetryUID = "disabled"
+	if IsTelemetryEnabled(c) {
+		log.Debug("  Getting Telemetry uid")
+		l.TelemetryUID, _ = GetTelemetryUid(c)
+	}
+
+	log.Debug("  Getting Local cluster")
+	localClusterID := ""
+	localFilter := NonRemoved()
+	localFilter.Filters["internal"] = true
+	clusterList, err := c.Client.Cluster.ListAll(&localFilter)
+	if err != nil {
+		log.Errorf("    Failed to get Local Cluster err=%s", err)
+	}
+	if clusterList != nil && len(clusterList.Data) == 1 {
+		localClusterID = clusterList.Data[0].ID
+		log.Debug("    Local cluster found")
+	} else {
+		log.Debug("    Local cluster NOT found")
+	}
+
+	log.Debug("  Getting Nodes")
+
+	nodeFilter := NonRemoved()
+	nodeFilter.Filters["clusterId_ne"] = localClusterID
+	nodeList, err := c.Client.Node.ListAll(&nodeFilter)
+	if err != nil {
+		log.Errorf("    Failed collect running nodes info err=%s", err)
+		return nil
+	}
+	log.Debugf("    Found %d Nodes", len(nodeList.Data))
+	l.RunningNodes = len(nodeList.Data)
+
+	return l
+}
+
+func GetLicenseKey(c *CollectorOpts) (string, bool) {
+	licenseKey, err := c.Client.Setting.ByID(SERVER_LICENSE_SETTING)
+	if err != nil {
+		if IsNotFound(err) {
+			log.Debugf("  Setting %s doesn't exist", SERVER_LICENSE_SETTING)
+		} else {
+			log.Errorf("  Failed to get setting %s err=%s", SERVER_LICENSE_SETTING, err)
+		}
+		return "", false
+	}
+
+	key := licenseKey.Value
+	if len(key) == 0 {
+		log.Debug("  No license key")
+		return "", false
+	}
+
+	log.Debugf("  License key: %s", key)
+
+	return key, true
+}
+
+func (l *License) GetKey(c *CollectorOpts) bool {
+	key, ok := GetLicenseKey(c)
+	l.Key = key
+
+	return ok
+}
+
+func IsLicensed(c *CollectorOpts) bool {
+	_, license := GetLicenseKey(c)
+	return license
+}
+
+func GetInstallationUid(c *CollectorOpts) (string, bool) {
+	installUid, err := c.Client.Setting.ByID(INSTALLATION_UID_SETTING)
+	if err != nil {
+		log.Errorf("  Failed to get setting %s err=%s", INSTALLATION_UID_SETTING, err)
+		return "", false
+	}
+
+	return installUid.Value, true
+}
+
+func (l *License) GetInstallationUid(c *CollectorOpts) bool {
+	installUid, ok := GetInstallationUid(c)
+	l.InstallationUID = installUid
+
+	return ok
+}
+
+func init() {
+	Register(License{})
+}

--- a/publish/tourl.go
+++ b/publish/tourl.go
@@ -35,32 +35,32 @@ func NewToUrl(c *cli.Context, uri string) *ToUrl {
 	return out
 }
 
-func (p *ToUrl) Report(r record.Record, clientIp string) error {
+func (p *ToUrl) Report(r record.Record, clientIp string) ([]byte, error) {
 	if p.url == "" {
-		return nil
+		return nil, nil
 	}
 
 	b, err := json.Marshal(r)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	res, err := http.Post(p.url, "application/json", bytes.NewBuffer(b))
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	defer res.Body.Close()
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if res.StatusCode >= 200 && res.StatusCode <= 299 {
 		log.Debugf(fmt.Sprintf("Server said %d: %s", res.StatusCode, body))
-		return nil
+		return body, nil
 	} else {
 		log.Errorf(fmt.Sprintf("Server said %d: %s", res.StatusCode, body))
-		return errors.New(fmt.Sprintf("Server returned %d", res.StatusCode))
+		return nil, errors.New(fmt.Sprintf("Server returned %d", res.StatusCode))
 	}
 }

--- a/publish/tourl.go
+++ b/publish/tourl.go
@@ -22,10 +22,10 @@ type ToUrl struct {
 	rancherVersion   string
 }
 
-func NewToUrl(c *cli.Context) *ToUrl {
+func NewToUrl(c *cli.Context, uri string) *ToUrl {
 	out := &ToUrl{
 		telemetryVersion: c.App.Version,
-		url:              c.String("to-url"),
+		url:              c.String("to-url") + uri,
 	}
 
 	if out.url == "" {

--- a/scripts/create_db.sql
+++ b/scripts/create_db.sql
@@ -33,3 +33,63 @@ CREATE TABLE account (
   name varchar(255) NOT NULL UNIQUE,
   hash varchar(255)
 );
+
+CREATE TABLE license_installation_record (
+  id serial PRIMARY KEY,
+  uid varchar(255) NOT NULL,
+  license_key varchar(255) NOT NULL,
+  telemetry_uid varchar(255) NOT NULL,
+  ts timestamp,
+  data json
+);
+
+CREATE INDEX license_installation_record_uid ON license_installation_record USING btree(uid);
+
+CREATE INDEX license_installation_record_ts_uid ON license_installation_record USING btree(ts,uid);
+
+CREATE TABLE license_record (
+  id serial PRIMARY KEY,
+  key varchar(255)  NOT NULL,
+  ts timestamp,
+  data json
+);
+
+CREATE INDEX license_record_key ON license_record USING btree(key);
+
+CREATE INDEX license_record_ts_key ON license_record USING btree(ts,key);
+
+CREATE TABLE license (
+  id serial PRIMARY KEY,
+  key varchar(255) UNIQUE NOT NULL,
+  first_seen timestamp,
+  last_ip varchar(255),
+  last_seen timestamp,
+  last_record int REFERENCES license_record(id),
+  licensed_installations int NOT NULL,
+  licensed_nodes int NOT NULL,
+  valid_from timestamp NOT NULL,
+  valid_to timestamp NOT NULL,
+  note text
+);
+
+CREATE INDEX license_uid ON license USING btree(uid);
+
+CREATE INDEX license_last_seen ON license USING btree(last_seen);
+
+CREATE TABLE license_installation (
+  id serial PRIMARY KEY,
+  uid varchar(255) UNIQUE NOT NULL,
+  license_key varchar(255) REFERENCES license(key),
+  telemetry_uid varchar(255) NOT NULL,
+  first_seen timestamp,
+  last_seen timestamp,
+  last_ip varchar(255),
+  last_record int REFERENCES license_installation_record(id),
+  note text,
+  running_nodes int NOT NULL
+);
+
+CREATE INDEX license_installation_uid ON license_installation USING btree(uid);
+
+CREATE INDEX license_installation_last_seen ON license_installation USING btree(last_seen);
+


### PR DESCRIPTION
This PR contains:
- telemetry client license collector to generate license records and report to server

```
  "license": {
    "key": "XXXX",
    "installationUid": "XXXXXXXXXXXXX",
    "telemetryUid": "disabled",
    "nodeCount": 0
  }
```

- updated telemetry db schema adding license tables
- updated telemetry server to register and check license records

This is a WIP related with [Rancher License monitoring tool
](https://github.com/rancherlabs/rancher-security/issues/332)