### PR TITLE
Return cluster collector data if logging isn't available

### DIFF
--- a/collector/cluster.go
+++ b/collector/cluster.go
@@ -156,28 +156,27 @@ func (h Cluster) Collect(c *CollectorOpts) interface{} {
 	h.LogProviderCount = make(LabelCount)
 
 	logList, err := c.Client.ClusterLogging.ListAll(nil)
-	if err != nil {
-		log.Errorf("Failed to get Cluster Loggings err=%s", err)
-		return nil
-	}
-
-	for _, logging := range logList.Data {
-		if logging.AppliedSpec != nil {
-			switch {
-			case logging.AppliedSpec.ElasticsearchConfig != nil:
-				h.LogProviderCount["Elasticsearch"]++
-			case logging.AppliedSpec.SplunkConfig != nil:
-				h.LogProviderCount["Splunk"]++
-			case logging.AppliedSpec.KafkaConfig != nil:
-				h.LogProviderCount["Kafka"]++
-			case logging.AppliedSpec.SyslogConfig != nil:
-				h.LogProviderCount["Syslog"]++
-			case logging.AppliedSpec.FluentForwarderConfig != nil:
-				h.LogProviderCount["Fluentd"]++
-			case logging.AppliedSpec.CustomTargetConfig != nil:
-				h.LogProviderCount["Custom"]++
+	if err == nil {
+		for _, logging := range logList.Data {
+			if logging.AppliedSpec != nil {
+				switch {
+				case logging.AppliedSpec.ElasticsearchConfig != nil:
+					h.LogProviderCount["Elasticsearch"]++
+				case logging.AppliedSpec.SplunkConfig != nil:
+					h.LogProviderCount["Splunk"]++
+				case logging.AppliedSpec.KafkaConfig != nil:
+					h.LogProviderCount["Kafka"]++
+				case logging.AppliedSpec.SyslogConfig != nil:
+					h.LogProviderCount["Syslog"]++
+				case logging.AppliedSpec.FluentForwarderConfig != nil:
+					h.LogProviderCount["Fluentd"]++
+				case logging.AppliedSpec.CustomTargetConfig != nil:
+					h.LogProviderCount["Custom"]++
+				}
 			}
 		}
+	} else {
+		log.Errorf("Failed to get Cluster Loggings err=%s", err)
 	}
 
 	return h


### PR DESCRIPTION
So, apparently there are quite a few options to use to persist logs in a Kubernetes cluster. If none of those options mentioned in the code are used, the execution of the code is aborted and no data is returned.

I was testing and I didn't get a report. I didn't have logging but still required the data to be returned and haven't found a reason why the report should not be sent just because logging isn't configured, especially considering that previous data has been collected successfully.

This PR changes exactly that. It ignores the fact that logging may not be set up as expected and still returns data which results in a telemetry report being sent.